### PR TITLE
Query abstraction and initial work on one-to-one relationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "xo",
     "fixlint": "xo --fix",
     "test": "xo && mocha --compilers js:babel-core/register -R spec --recursive ./test",
-    "test-watch": "xo 7& mocha --compilers js:babel-core/register -R spec --watch --recursive ./test",
+    "test-watch": "xo && mocha --compilers js:babel-core/register -R spec --watch --recursive ./test",
     "coverage": "xo && babel-node ./node_modules/.bin/isparta cover _mocha -- -R spec --recursive ./test"
   },
   "main": "src/index.js",
@@ -102,7 +102,8 @@
             "string": "String"
           }
         }
-      ]
+      ],
+      "no-console": "error"
     }
   }
 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -35,7 +35,7 @@ export default class Model {
         const parent = this;
 
         const obj = function () {
-            parent.apply(this, Array.prototype.slice(arguments));
+            parent.apply(this, Array.prototype.slice.call(arguments));
         };
         Object.defineProperty(obj, 'name', { 'value': name });
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -239,7 +239,7 @@ export default class Session {
      * @returns {Promise} - A promise fulfilled by the result of the query
      */
     _find(cls, conditions, options = {}) {
-        const query = new FindQueryBuilder(cls, conditions, options);
+        const query = new FindQueryBuilder(cls, conditions, options, this);
         return Promise.resolve(this.adapter.find(query.toQueryObject()));
     }
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -2,6 +2,7 @@ import './utils/object-values-polyfill';
 import './utils/object-foreach-polyfill';
 import * as Utils from './utils/model-utils';
 import Model from './Model';
+import FindQueryBuilder from './query/FindQueryBuilder';
 
 /**
  * The Session class is the core and root of the One ORM core library. The
@@ -36,23 +37,14 @@ export default class Session {
      */
     model(name, fields, options) {
         options = options || {};
-        options.instance = this;
+        if (options.extend && !(options.extend instanceof Model)) {
+            throw new Error('Model must extend another model');
+        }
 
         const obj = Model.extend(name, fields, options);
         delete obj.prototype.super;
+        this.models[name] = obj;
         return obj;
-    }
-
-    /**
-     * Registers the given model with the session using the given name.
-     *
-     * @param {String} name - The name of the new model
-     * @param {Object} model - The new model
-     * @returns {Model} - The model supplied
-     */
-    register(name, model) {
-        this.models[name] = model;
-        return model;
     }
 
     /**
@@ -202,7 +194,7 @@ export default class Session {
             );
         }
 
-        const ancestors = Utils.getAncestors(instance);
+        const ancestors = Utils.getAncestors(instance, this);
 
         const buildRemoveQuery = function (entity) {
             entity = Utils.getModel(entity);
@@ -247,32 +239,8 @@ export default class Session {
      * @returns {Promise} - A promise fulfilled by the result of the query
      */
     _find(cls, conditions, options = {}) {
-        const ast = {
-            'columns': this.buildColumnsForQuery(cls, options),
-            'from': cls._modelMeta.table,
-            'as': cls.name
-        };
-
-        // Handle joins
-        const _joins = this.buildJoinsForQuery(cls);
-        if (_joins) {
-            ast.join = _joins;
-        }
-        // Build conditions
-        const _conditions = this.buildConditionsForQuery(cls, conditions);
-        if (_conditions) {
-            ast.where = _conditions;
-        }
-        // Skip
-        if (options.skip) {
-            ast.skip = options.skip;
-        }
-        // Limit
-        if (options.limit) {
-            ast.limit = options.limit;
-        }
-
-        return Promise.resolve(this.adapter.find(ast));
+        const query = new FindQueryBuilder(cls, conditions, options);
+        return Promise.resolve(this.adapter.find(query.toQueryObject()));
     }
 
     /**
@@ -305,139 +273,6 @@ export default class Session {
             .getAncestors(instance)
             .map(getInsertForModel)
             .concat(getInsertForModel(instance.constructor));
-    }
-
-    /** ************************************************************************
-     * Low-level utilities
-     ************************************************************************ */
-    /**
-     * Builds the column identifiers used to produce datastore queries. These
-     * identifiers may include table names or other identifying information as
-     * required.
-     *
-     * @private
-     * @param {Model} model - The model to get columns for
-     * @param {Object} [options] - Additional options governing the query
-     * @param {String[]} [options.include] - Additional columns to add to the
-     *         query
-     * @param {String[]} [options.exclude] - Columns to remove from the query
-     * @returns {String[]} - The list of column identifiers
-     */
-    buildColumnsForQuery(model, options) {
-        const _options = Object.assign({
-            'include': [],
-            'exclude': []
-        }, options);
-
-        const fields = Utils.getAncestors(model)
-            .concat(model)
-            .reduce((result, entity) => {
-                result = Object.assign({}, result, Utils.getFields(entity));
-                return result;
-            }, {});
-
-        const columns = Object.values(fields)
-            .filter((field) => {
-                // Handle inclusions and exclusions
-                return _options.exclude.indexOf(field.name) === -1
-                        || _options.include.indexOf(field.name) !== -1;
-            })
-            .map((field) => {
-                return field.owningModel + '.' + field.column;
-            });
-        _options.include.forEach((includeName) => {
-            if (!(includeName in fields)) {
-                columns.push(includeName);
-            }
-        });
-        return columns;
-    }
-
-    /**
-     * TODO Description required
-     *
-     * @private
-     * @param {Model} model - The model to build conditions for
-     * @param {Object[]} conditions - The condition representations
-     * @returns {Object} - A map of conditions
-     */
-    buildConditionsForQuery(model, conditions) {
-        if (!conditions || Object.keys(conditions).length === 0) {
-            return;
-        }
-
-        const fields = Utils.getAllFields(model);
-        const result = {};
-
-        Object.forEach(conditions, (condition, key) => {
-            if (key.indexOf('.') === -1) {
-                const field = fields[key];
-                result[field.owningModel + '.' + field.column] = condition;
-            } else {
-                result[key] = condition;
-            }
-        });
-        return result;
-    }
-
-    /**
-     * Determines which joins are needed in order to retrieve the correct
-     * information all at the same time.
-     *
-     * @private
-     * @param {Model} model - The model to build joins for
-     * @returns {Object[]} - A list of join definitions
-     */
-    buildJoinsForQuery(model) {
-        if (model._modelMeta.options.extends) {
-            const parent = Utils.getParent(model);
-            return [{
-                'to': parent._modelMeta.options.table,
-                'as': parent.name,
-                'on': this.relatePrimaryKeys(model)
-            }];
-        }
-    }
-
-    /**
-     * Relates the primary keys of a parent model to the primary keys of a child
-     * model, such that the proper joins may be made.
-     *
-     * @private
-     * @param {Model} model - The model to relate keys for
-     * @returns {Object} - A map keyed by child key to the related parent key
-     */
-    relatePrimaryKeys(model) {
-        const localFields = Utils.getFields(model);
-        let localPrimaries = Object.keys(localFields)
-            .filter((fieldName) => {
-                return localFields[fieldName].primary;
-            })
-            .map((fieldName) => {
-                return localFields[fieldName];
-            });
-        const parentFields = Utils.getFields(Utils.getParent(model));
-        const parentPrimaries = Object.keys(parentFields)
-            .filter((fieldName) => {
-                return parentFields[fieldName].primary;
-            })
-            .map((fieldName) => {
-                return parentFields[fieldName];
-            });
-
-        // TODO We just assume that the dev has added identical primary keys to
-        // the child table
-        if (localPrimaries.length === 0) {
-            localPrimaries = parentPrimaries.slice();
-        }
-
-        if (localPrimaries.length !== parentPrimaries.length) {
-            throw new Error('Primary key count mismatch between ' + this._modelMeta.name + ' and parent ' + this._modelMeta.options.extends._modelMeta.name);
-        }
-
-        if (localPrimaries.length === 1) {
-            return { [localPrimaries[0].name]: parentPrimaries[0].name };
-        }
     }
 
 }

--- a/src/query/FindQueryBuilder.js
+++ b/src/query/FindQueryBuilder.js
@@ -1,0 +1,205 @@
+import * as ModelUtils from '../utils/model-utils';
+import * as JoinUtils from '../utils/join-utils';
+import QueryBuilder from './QueryBuilder';
+
+/**
+ * The FindQueryBuilder is responsible for generating a query representation
+ * that may be used to effect a `find` operation on the underlying datastore.
+ * This involves keeping track of fields/columns requested, entities joined on,
+ * conditions to be applied, and other SQL-esque bits of info.
+ */
+export default class FindQueryBuilder extends QueryBuilder {
+    /**
+     * Build a new instance of the FindQueryBuilder.
+     *
+     * @param {Model} model - The root model to be queried upon
+     * @param {Object} [conditions] - Any conditions to be applied to the query
+     * @param {Object} [options] - Any additional options governing the query
+     */
+    constructor(model, conditions, options) {
+        super();
+
+        this.options = Object.assign({
+            'include': [],
+            'exclude': []
+        }, options);
+
+        this._fields = [];
+        this._joins = [];
+        this._joinFromLookup = [];
+
+		// Add the model and fields
+        this._root = model;
+        this._from = model._modelMeta.options.table;
+        this._as = model.name;
+
+        // Process the root's fields
+        this.addFields(this._as, this._as, ModelUtils.getFields(this._root));
+
+        // Process the root's hierarchy where applicable
+        this.joinParent(this._root, this._as);
+
+        // TODO Implement condition handling
+        // TODO Validate conditions
+    }
+
+    /**
+     * Assuming the supplied entity graph has not yet been fully joined in the
+     * query, traverses the entity graph and joins each node where required,
+     * pulling in all fields for each node along the way, except where
+     * specified.
+     *
+     * @param {String} graph - The entity graph path to the field to join on
+     * @param {Object[]} fields - A list of fields to retrieve from the target
+     *         table
+     * @returns {String} - The alias of the newly joined table
+     */
+    join(graph, fields) {
+        // If we've already joined on this graph, do nothing
+        if (this._joinFromLookup[graph]) {
+            return;
+        }
+
+        // Parse the supplied entity graph
+        const parts = graph.split('.');
+        if (parts[0] !== this._as) {
+            throw new Error('The first element of the entity graph must be the root entity of the query.');
+        }
+
+        let lastModel = this._root;
+        let lastAlias = this._as;
+        let lastFrom = parts.shift();
+        parts.forEach((part) => {
+            if (part === '$$parent') {
+                const thisModel = ModelUtils.getParent(this._root);
+                const thisAlias = this.tableAlias(thisModel.name);
+                lastFrom += '.' + part;
+                this._joins.push({
+                    'table': thisModel._modelMeta.options.table,
+                    'as': thisAlias,
+                    'on': JoinUtils.getJoinColumnsFromChildToParent(lastModel, lastAlias, thisAlias),
+                    'from': lastFrom
+                });
+                lastModel = thisModel;
+                lastAlias = thisAlias;
+            }
+        });
+        this.addFields(fields, lastAlias);
+        return lastAlias;
+    }
+
+    /**
+     * Builds the join from the given child to it's parent, adding the join
+     * clause and all but the excluded fields configured on that parent model.
+     *
+     * @param {Model} child - The child model to find and join with the parent
+     * @param {String} childAlias - The child's alias used in the query, for
+     *         determining field and table identifiers
+     */
+    joinParent(child, childAlias) {
+        const parent = ModelUtils.getParent(child);
+        if (!parent) {
+            return;
+        }
+
+        const parentAlias = this.tableAlias(parent.name);
+        this._joins.push({
+            'table': parent._modelMeta.options.table,
+            'as': parentAlias,
+            'on': JoinUtils.getJoinColumnsFromChildToParent(child, childAlias, parentAlias),
+            'from': childAlias
+        });
+
+        // Add fields
+        const fields = ModelUtils.getFields(parent);
+        this.addFields(this._as, parentAlias, fields);
+
+        this.joinParent(parent, parentAlias);
+    }
+
+    /**
+     * Produces a plain-object representation of the query that should be run
+     * by the dialect implementation.
+     *
+     * @returns {Object} - The plain-object query representation
+     */
+    toQueryObject() {
+        const result = {};
+        result.columns = this._fields.map((f) => {
+            return [f.column, f.column.replace('.', '_')];
+        });
+        result.from = this._from;
+        result.as = this._as;
+        if (this._joins.length > 0) {
+            result.join = this._joins.map((j) => {
+                return {
+                    'to': j.table,
+                    'as': j.as,
+                    'on': j.on
+                };
+            });
+        }
+        if (this.options.skip) {
+            result.skip = this.options.skip;
+        }
+        if (this.options.limit) {
+            result.limit = this.options.limit;
+        }
+        return result;
+    }
+
+	//
+	// Utilities
+	//
+    /**
+     * Adds fields from the supplied list to the list of fields that will be
+     * retrieved from the underlying datastore. Performs field inclusion and
+     * exclusion based on the graph of the entity to which the fields belong.
+     *
+     * @private
+     * @param {String} graph - The entity graph, terminating at the owner of the
+     *         fields provided
+     * @param {String} alias - The alias of the owner of the fields provided
+     * @param {Object} fields - The map of fields to potentially add, keyed by
+     *         field name
+     * @returns {undefined} - Returns nothing
+     */
+    addFields(graph, alias, fields) {
+        if (!fields || !~Object.keys(fields).length) {
+            return;
+        }
+        Object.keys(fields).forEach((key) => {
+            const field = fields[key];
+
+            // Priorities:
+            // 1) Explicit exclude
+            // 2) Explicit include
+            // 3) Model exclude
+            const _graph = graph + '.' + key;
+            if (this.options.exclude.indexOf(_graph) !== -1
+                    || (field.exclude && this.options.include.indexOf(_graph) === -1)) {
+                return;
+            }
+            this._fields.push({
+                'column': alias + '.' + field.column,
+                field
+            });
+        });
+    }
+
+    // /**
+    //  * @private
+    //  */
+    // addFields(fields, alias) {
+    //     Object.keys(fields).forEach((key) => {
+    //         const field = fields[key];
+    //         if (field.exclude) {
+    //             return;
+    //         }
+    //         this._fields.push({
+    //             'column': alias + '.' + field.column,
+    //             field
+    //         });
+    //     });
+    // }
+}

--- a/src/query/FindQueryBuilder.js
+++ b/src/query/FindQueryBuilder.js
@@ -1,5 +1,6 @@
 import * as ModelUtils from '../utils/model-utils';
 import * as JoinUtils from '../utils/join-utils';
+import * as GraphUtils from '../utils/graph-utils';
 import QueryBuilder from './QueryBuilder';
 
 /**
@@ -41,80 +42,6 @@ export default class FindQueryBuilder extends QueryBuilder {
 
         // TODO Implement condition handling
         // TODO Validate conditions
-    }
-
-    /**
-     * Assuming the supplied entity graph has not yet been fully joined in the
-     * query, traverses the entity graph and joins each node where required,
-     * pulling in all fields for each node along the way, except where
-     * specified.
-     *
-     * @param {String} graph - The entity graph path to the field to join on
-     * @param {Object[]} fields - A list of fields to retrieve from the target
-     *         table
-     * @returns {String} - The alias of the newly joined table
-     */
-    join(graph, fields) {
-        // If we've already joined on this graph, do nothing
-        if (this._joinFromLookup[graph]) {
-            return;
-        }
-
-        // Parse the supplied entity graph
-        const parts = graph.split('.');
-        if (parts[0] !== this._as) {
-            throw new Error('The first element of the entity graph must be the root entity of the query.');
-        }
-
-        let lastModel = this._root;
-        let lastAlias = this._as;
-        let lastFrom = parts.shift();
-        parts.forEach((part) => {
-            if (part === '$$parent') {
-                const thisModel = ModelUtils.getParent(this._root);
-                const thisAlias = this.tableAlias(thisModel.name);
-                lastFrom += '.' + part;
-                this._joins.push({
-                    'table': thisModel._modelMeta.options.table,
-                    'as': thisAlias,
-                    'on': JoinUtils.getJoinColumnsFromChildToParent(lastModel, lastAlias, thisAlias),
-                    'from': lastFrom
-                });
-                lastModel = thisModel;
-                lastAlias = thisAlias;
-            }
-        });
-        this.addFields(fields, lastAlias);
-        return lastAlias;
-    }
-
-    /**
-     * Builds the join from the given child to it's parent, adding the join
-     * clause and all but the excluded fields configured on that parent model.
-     *
-     * @param {Model} child - The child model to find and join with the parent
-     * @param {String} childAlias - The child's alias used in the query, for
-     *         determining field and table identifiers
-     */
-    joinParent(child, childAlias) {
-        const parent = ModelUtils.getParent(child);
-        if (!parent) {
-            return;
-        }
-
-        const parentAlias = this.tableAlias(parent.name);
-        this._joins.push({
-            'table': parent._modelMeta.options.table,
-            'as': parentAlias,
-            'on': JoinUtils.getJoinColumnsFromChildToParent(child, childAlias, parentAlias),
-            'from': childAlias
-        });
-
-        // Add fields
-        const fields = ModelUtils.getFields(parent);
-        this.addFields(this._as, parentAlias, fields);
-
-        this.joinParent(parent, parentAlias);
     }
 
     /**
@@ -180,6 +107,14 @@ export default class FindQueryBuilder extends QueryBuilder {
                     || (field.exclude && this.options.include.indexOf(_graph) === -1)) {
                 return;
             }
+
+            // If this is a relational field
+            if (field.ref && (field.eager
+                    || this.options.include.indexOf(_graph) !== -1)) {
+                this.join(_graph);
+                return;
+            }
+
             this._fields.push({
                 'column': alias + '.' + field.column,
                 field
@@ -187,19 +122,85 @@ export default class FindQueryBuilder extends QueryBuilder {
         });
     }
 
-    // /**
-    //  * @private
-    //  */
-    // addFields(fields, alias) {
-    //     Object.keys(fields).forEach((key) => {
-    //         const field = fields[key];
-    //         if (field.exclude) {
-    //             return;
-    //         }
-    //         this._fields.push({
-    //             'column': alias + '.' + field.column,
-    //             field
-    //         });
-    //     });
-    // }
+    /**
+     * Assuming the supplied entity graph has not yet been fully joined in the
+     * query, traverses the entity graph and joins each node where required,
+     * pulling in all fields for each node along the way, except where
+     * specified.
+     *
+     * @param {String} graph - The entity graph path to the field to join on
+     * @returns {String} - The alias of the newly joined table
+     */
+    join(graph) {
+        // Parse the supplied entity graph
+        const first = graph.indexOf('.');
+        if (first === -1) {
+            throw new Error('Cannot join on a single-segment graph');
+        }
+        if (graph.substr(0, first) !== this._root.name) {
+            throw new Error('Join graphs must be relative to the query root');
+        }
+
+        const nodes = GraphUtils.resolveGraph(graph, this._root);
+
+        let lastNode = nodes.shift();
+        let lastGraph = lastNode.key;
+        let lastAlias = this._as;
+        nodes.forEach((node) => {
+            const currentGraph = lastGraph + '.' + node.key;
+            const existingAlias = this._joinFromLookup[currentGraph];
+            if (existingAlias) {
+                lastGraph = currentGraph;
+                lastNode = node;
+                lastAlias = existingAlias;
+                return;
+            }
+
+            // TODO We want to join on the current graph
+            const alias = this.tableAlias(node.ref.name);
+            this._joins.push({
+                'table': node.ref._modelMeta.options.table,
+                'as': alias,
+                'on': JoinUtils.getJoinColumns(lastNode.ref, node.key, lastAlias, alias),
+                'from': currentGraph
+            });
+            lastGraph = currentGraph;
+            lastNode = node;
+            lastAlias = alias;
+
+            this.addFields(lastGraph, lastAlias, ModelUtils.getFields(lastNode.ref));
+            this.joinParent(lastNode.ref, lastAlias);
+        });
+        return lastAlias;
+    }
+
+    /**
+     * Builds the join from the given child to it's parent, adding the join
+     * clause and all but the excluded fields configured on that parent model.
+     *
+     * @private
+     * @param {Model} child - The child model to find and join with the parent
+     * @param {String} childAlias - The child's alias used in the query, for
+     *         determining field and table identifiers
+     */
+    joinParent(child, childAlias) {
+        const parent = ModelUtils.getParent(child);
+        if (!parent) {
+            return;
+        }
+
+        const parentAlias = this.tableAlias(parent.name);
+        this._joins.push({
+            'table': parent._modelMeta.options.table,
+            'as': parentAlias,
+            'on': JoinUtils.getJoinColumnsFromChildToParent(child, childAlias, parentAlias),
+            'from': childAlias
+        });
+
+        // Add fields
+        const fields = ModelUtils.getFields(parent);
+        this.addFields(this._as, parentAlias, fields);
+
+        this.joinParent(parent, parentAlias);
+    }
 }

--- a/src/query/QueryBuilder.js
+++ b/src/query/QueryBuilder.js
@@ -25,10 +25,10 @@ export default class QueryBuilder {
      * @returns {String} - The new, unique alias
      */
     tableAlias(name) {
-        if (this._counters[name]) {
-            this._counters[name] += 1;
-        } else {
+        if (typeof this._counters[name] === 'undefined') {
             this._counters[name] = 0;
+        } else {
+            this._counters[name] += 1;
         }
         return name + this._counters[name];
     }

--- a/src/query/QueryBuilder.js
+++ b/src/query/QueryBuilder.js
@@ -1,0 +1,35 @@
+/**
+ * The QueryBuilder class contains implementation details common to all
+ * implementations. QueryBuilder implementations take incoming information such
+ * as the root entity of the query, includes/excludes, conditions, and other
+ * infomration and build a query representation out of that information which
+ * can then be passed to an Adapter in order to manipulate information in the
+ * underlying datastore.
+ *
+ * @abstract
+ */
+export default class QueryBuilder {
+    /**
+     * Build a new instance of the QueryBuilder.
+     */
+    constructor() {
+        this._counters = {};
+        this._entities = {};
+    }
+
+    /**
+     * Build a table alias to use in a query. Just takes the given name and
+     * appends a number to it, then increments the number for that name so that,
+     * should the name ever appear again, a new number will be given.
+     * @param {String} name - The name of the table or model to alias
+     * @returns {String} - The new, unique alias
+     */
+    tableAlias(name) {
+        if (this._counters[name]) {
+            this._counters[name] += 1;
+        } else {
+            this._counters[name] = 0;
+        }
+        return name + this._counters[name];
+    }
+}

--- a/src/utils/graph-utils.js
+++ b/src/utils/graph-utils.js
@@ -1,0 +1,92 @@
+/* eslint import/prefer-default-export: "off" */
+
+import * as ModelUtils from './model-utils';
+
+/**
+ * Breaks down the supplied entity graph and returns an array of objects, where
+ * each object in the array represents a single node in the graph. Each node
+ * representation may present the following properties:
+ *   - key: The path segment that textually represents the node. For example,
+ *         in the case of `Post.author.name`, you'd receive an array with three
+ *         elements, each with the keys `Post`, `author`, and `name`
+ *         respectively.
+ *   - type: The data type of the node. If the node is referential, it will not
+ *         have a `type`, but will have a `ref` instead.
+ *   - ref: If the node points to an entity, the ref property will be set to the
+ *         name of that entity.
+ *
+ * An example result from a call for the path `Post.author.name` might look
+ * something like:
+ *
+ * ```
+ * [{
+ *     key: 'Post',
+ *     ref: 'Post',
+ * }, {
+ *     key: 'author',
+ *     ref: 'User'
+ * }, {
+ *     key: 'name',
+ *     type: String
+ * }]
+ * ```
+ *
+ * @param {String} path - The textual graph representation to resolve
+ * @param {Session} session - The session to draw entities from
+ * @returns {Object[]|null} - A list of node representations or null if graph is
+ *         invalid
+ */
+export function resolveGraph(path, session) {
+    if (!session || !path || !path.substr || path.length === 0) {
+        return null;
+    }
+
+	// If the graph is a single segment
+    if (path.indexOf('.') === -1) {
+        const entity = session.get(path);
+        if (!entity) {
+            return null;
+        }
+        return [{
+            'key': path,
+            'ref': entity.name
+        }];
+    }
+
+	// If the graph is more than one segment
+    let result = [];
+    const parts = path.split('.');
+    const previousKey = parts.shift();
+    let previousEntity = session.get(previousKey);
+    if (!previousEntity) {
+        return null;
+    }
+    result.push({
+        'key': previousKey,
+        'ref': previousEntity.name
+    });
+
+    parts.forEach((part) => {
+        if (result === null) {
+            return;
+        }
+
+        const field = ModelUtils.getField(previousEntity, part);
+        if (!field) {
+            result = null;
+            return;
+        }
+
+        const node = {
+            'key': part
+        };
+        if (field.ref) {
+            node.ref = field.ref;
+            previousEntity = session.get(field.ref);
+        } else {
+            node.type = field.type;
+        }
+        result.push(node);
+    });
+    return result;
+}

--- a/src/utils/identifier-utils.js
+++ b/src/utils/identifier-utils.js
@@ -1,0 +1,16 @@
+/* eslint import/prefer-default-export: "off" */
+
+/**
+ * Prefixes the supplied column name with the given alias. If no alias is
+ * provided, the column is returned unaltered.
+ *
+ * @param {String} column - The column name to prefix
+ * @param {String} alias - The alias to prepend to the column name
+ * @returns {String} - The alias and column as an identifier
+ */
+export function prefixAlias(column, alias) {
+    if (!alias) {
+        return column;
+    }
+    return alias + '.' + column;
+}

--- a/src/utils/join-utils.js
+++ b/src/utils/join-utils.js
@@ -1,0 +1,38 @@
+/* eslint import/prefer-default-export: "off" */
+
+import * as ModelUtils from './model-utils';
+import * as IdentUtils from './identifier-utils';
+
+/**
+ * Builds a map of foreign key to primary key columns between the supplied child
+ * model and its parent model. The map is keyed by the child foreign key
+ * columns.
+ *
+ * @param {Model} child - The child to find join columns for
+ * @param {String} [childAlias] - The alias that refers to the child entity in
+ *         the query this is to be used for
+ * @param {String} [parentAlias] - The alias that refers to the parent entity in
+ *         the query this is to be used for
+ * @returns {Object} - The map of child foreign key columns to parent primary
+ *         key columns
+ */
+export function getJoinColumnsFromChildToParent(child, childAlias, parentAlias) {
+    let childPrimaries = ModelUtils.getPrimaryFields(child);
+    const parentPrimaries = ModelUtils.getPrimaryFields(ModelUtils.getParent(child));
+
+	// If the child hasn't specified any primary keys, we inherit the identifier
+	// definition from the parent
+    if (childPrimaries.length === 0) {
+        childPrimaries = parentPrimaries.slice();
+    }
+
+    if (childPrimaries.length !== parentPrimaries.length) {
+        throw new Error('Primary key count mismatch between ' + ModelUtils.getName(child) + ' and parent ' + ModelUtils.getName(ModelUtils.getParent(child)));
+    }
+
+    if (childPrimaries.length === 1) {
+        const childName = IdentUtils.prefixAlias(childPrimaries[0].name, childAlias);
+        const parentName = IdentUtils.prefixAlias(parentPrimaries[0].name, parentAlias);
+        return { [childName]: parentName };
+    }
+}

--- a/src/utils/join-utils.js
+++ b/src/utils/join-utils.js
@@ -1,5 +1,3 @@
-/* eslint import/prefer-default-export: "off" */
-
 import * as ModelUtils from './model-utils';
 import * as IdentUtils from './identifier-utils';
 
@@ -35,4 +33,35 @@ export function getJoinColumnsFromChildToParent(child, childAlias, parentAlias) 
         const parentName = IdentUtils.prefixAlias(parentPrimaries[0].name, parentAlias);
         return { [childName]: parentName };
     }
+}
+
+/**
+ * Builds a map of foreign key to primary key columns between the supplied model
+ * and the model indicated by the given field.
+ *
+ * @param {Model} model - The model to join from
+ * @param {String} fieldName - The name of the field that points to the target
+ *         model
+ * @param {String} [sourceAlias] - The alias of the source entity
+ * @param {String} [targetAlias] - The alias of the target entity
+ * @returns {Object} - An object map keyed by source columns, pointing to target
+ *         columns
+ */
+export function getJoinColumns(model, fieldName, sourceAlias, targetAlias) {
+    // TODO Composite key support
+
+    const field = model._modelMeta.fields[fieldName];
+    if (!field.ref) {
+        throw new Error('Cannot join on a field that does not refer to another model');
+    }
+
+    // Get the primary key of the target entity
+    const targetPrimaryFields = ModelUtils.getPrimaryFields(field.ref);
+    if (targetPrimaryFields.length > 1) {
+        throw new Error('Composite keys are not yet supported');
+    }
+
+    return {
+        [IdentUtils.prefixAlias(field.column, sourceAlias)]: IdentUtils.prefixAlias(targetPrimaryFields[0].column, targetAlias)
+    };
 }

--- a/test/unit/complete-domain-example.js
+++ b/test/unit/complete-domain-example.js
@@ -4,8 +4,8 @@
 //
 // The first usage of any feature should be noted.
 //
-import sinon from 'sinon';
 import Session from '../../src/Session';
+import { adapterSpy } from './utils';
 
 const session = new Session();
 export default session;
@@ -37,6 +37,10 @@ const User = session.model('User', {
     },
     'role': {
         'type': String
+    },
+    'password': {
+        'type': String,
+        'exclude': true
     }
 }, {
     'table': 'users'
@@ -66,7 +70,14 @@ const Post = session.model('Post', {
         'type': String
     },
     'author': {
-        'ref': 'User' // Foreign key to another table/model
+        'ref': 'User', // Foreign key to another table/model
+        'relation': 'one-to-one', // Type of the relationship
+        'column': 'author_id'
+    },
+    'editor': {
+        'ref': 'User',
+        'relation': 'one-to-one',
+        'column': 'editor_id'
     },
     'created': {
         'type': Date
@@ -76,12 +87,4 @@ const Post = session.model('Post', {
 });
 export { User, Client, Post };
 
-const adapterSpy = function () {
-    return {
-        'find': sinon.spy(),
-        'create': sinon.spy(),
-        'update': sinon.spy(),
-        'remove': sinon.spy()
-    };
-};
 export { adapterSpy };

--- a/test/unit/interactions/FindTest.js
+++ b/test/unit/interactions/FindTest.js
@@ -1,4 +1,4 @@
-/* eslint max-nested-callbacks: ["error", 5] */
+/* eslint max-nested-callbacks: ['error', 5] */
 
 import { expect } from 'chai';
 import session, { User, Client, adapterSpy } from '../complete-domain-example';
@@ -10,201 +10,122 @@ describe('Session', () => {
 
     // Any tests for the _find common implementation likely go here
     describe('findAll()', () => {
-        describe('Without inheritance', () => {
-            describe('Attribute inclusion/exclusion', () => {
-                it('Can include additional attributes', () => {
-                    session.findAll(User, null, {
-                        'include': ['foobar']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role',
-                            'foobar'
-                        ],
-                        'from': 'users',
-                        'as': 'User'
-                    });
-                });
-                it('Can exclude attributes', () => {
-                    session.findAll(User, null, {
-                        'exclude': ['email']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.register_date',
-                            'User.role'
-                        ],
-                        'from': 'users',
-                        'as': 'User'
-                    });
-                });
-                it('Include takes priority', () => {
-                    session.findAll(User, null, {
-                        'include': ['email'],
-                        'exclude': ['email']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role'
-                        ],
-                        'from': 'users',
-                        'as': 'User'
-                    });
-                });
-            });
-
-            describe('Handles conditions', () => {
-                it('Handles conditions', () => {
-                    session.findAll(User, {
-                        'role': 'admin'
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role'
-                        ],
-                        'from': 'users',
-                        'as': 'User',
-                        'where': {
-                            'User.role': 'admin'
-                        }
-                    });
-                });
+        it('Can make basic query', () => {
+            session.findAll(User, null);
+            expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+                'columns': [
+                    ['User.id', 'User_id'],
+                    ['User.firstName', 'User_firstName'],
+                    ['User.lastName', 'User_lastName'],
+                    ['User.username', 'User_username'],
+                    ['User.email', 'User_email'],
+                    ['User.register_date', 'User_register_date'],
+                    ['User.role', 'User_role']
+                ],
+                'from': 'users',
+                'as': 'User'
             });
         });
 
-        describe('With inheritance', () => {
-            describe('Attribute inclusion/exclusion', () => {
-                it('Can include additional attributes', () => {
-                    session.findAll(Client, null, {
-                        'include': ['foobar']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role',
-                            'Client.clientNum',
-                            'Client.representative',
-                            'foobar'
-                        ],
-                        'from': 'clients',
-                        'as': 'Client',
-                        'join': [{
-                            'to': 'users',
-                            'as': 'User',
-                            'on': { 'id': 'id' }
-                        }]
-                    });
-                });
-
-                it('Can exclude attributes', () => {
-                    session.findAll(Client, null, {
-                        'exclude': ['email']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.register_date',
-                            'User.role',
-                            'Client.clientNum',
-                            'Client.representative'
-                        ],
-                        'from': 'clients',
-                        'as': 'Client',
-                        'join': [{
-                            'to': 'users',
-                            'as': 'User',
-                            'on': { 'id': 'id' }
-                        }]
-                    });
-                });
-
-                it('Include takes priority', () => {
-                    session.findAll(Client, null, {
-                        'include': ['email'],
-                        'exclude': ['email']
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role',
-                            'Client.clientNum',
-                            'Client.representative'
-                        ],
-                        'from': 'clients',
-                        'as': 'Client',
-                        'join': [{
-                            'to': 'users',
-                            'as': 'User',
-                            'on': { 'id': 'id' }
-                        }]
-                    });
-                });
+        it('Can query inheritance hierarchy', () => {
+            session.findAll(Client);
+            expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+                'columns': [
+                    ['Client.clientNum', 'Client_clientNum'],
+                    ['Client.representative', 'Client_representative'],
+                    ['User0.id', 'User0_id'],
+                    ['User0.firstName', 'User0_firstName'],
+                    ['User0.lastName', 'User0_lastName'],
+                    ['User0.username', 'User0_username'],
+                    ['User0.email', 'User0_email'],
+                    ['User0.register_date', 'User0_register_date'],
+                    ['User0.role', 'User0_role']
+                ],
+                'from': 'clients',
+                'as': 'Client',
+                'join': [{
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': { 'Client.id': 'User0.id' }
+                }]
             });
+        });
 
-            describe('Handles conditions', () => {
-                it('Handles conditions', () => {
-                    session.findAll(Client, {
-                        'role': 'admin'
-                    });
-                    expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
-                        'columns': [
-                            'User.id',
-                            'User.firstName',
-                            'User.lastName',
-                            'User.username',
-                            'User.email',
-                            'User.register_date',
-                            'User.role',
-                            'Client.clientNum',
-                            'Client.representative'
-                        ],
-                        'from': 'clients',
-                        'as': 'Client',
-                        'join': [{
-                            'to': 'users',
-                            'as': 'User',
-                            'on': { 'id': 'id' }
-                        }],
-                        'where': {
-                            'User.role': 'admin'
-                        }
-                    });
-                });
+        it('Can include additional attributes', () => {
+            session.findAll(Client, null, {
+                'include': ['Client.password']
+            });
+            expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+                'columns': [
+                    ['Client.clientNum', 'Client_clientNum'],
+                    ['Client.representative', 'Client_representative'],
+                    ['User0.id', 'User0_id'],
+                    ['User0.firstName', 'User0_firstName'],
+                    ['User0.lastName', 'User0_lastName'],
+                    ['User0.username', 'User0_username'],
+                    ['User0.email', 'User0_email'],
+                    ['User0.register_date', 'User0_register_date'],
+                    ['User0.role', 'User0_role'],
+                    ['User0.password', 'User0_password']
+                ],
+                'from': 'clients',
+                'as': 'Client',
+                'join': [{
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': { 'Client.id': 'User0.id' }
+                }]
+            });
+        });
+
+        it('Can exclude attributes', () => {
+            session.findAll(Client, null, {
+                'exclude': ['Client.email']
+            });
+            expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+                'columns': [
+                    ['Client.clientNum', 'Client_clientNum'],
+                    ['Client.representative', 'Client_representative'],
+                    ['User0.id', 'User0_id'],
+                    ['User0.firstName', 'User0_firstName'],
+                    ['User0.lastName', 'User0_lastName'],
+                    ['User0.username', 'User0_username'],
+                    ['User0.register_date', 'User0_register_date'],
+                    ['User0.role', 'User0_role']
+                ],
+                'from': 'clients',
+                'as': 'Client',
+                'join': [{
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': { 'Client.id': 'User0.id' }
+                }]
+            });
+        });
+
+        it('Exclude takes priority', () => {
+            session.findAll(Client, null, {
+                'include': ['Client.email'],
+                'exclude': ['Client.email']
+            });
+            expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+                'columns': [
+                    ['Client.clientNum', 'Client_clientNum'],
+                    ['Client.representative', 'Client_representative'],
+                    ['User0.id', 'User0_id'],
+                    ['User0.firstName', 'User0_firstName'],
+                    ['User0.lastName', 'User0_lastName'],
+                    ['User0.username', 'User0_username'],
+                    ['User0.register_date', 'User0_register_date'],
+                    ['User0.role', 'User0_role']
+                ],
+                'from': 'clients',
+                'as': 'Client',
+                'join': [{
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': { 'Client.id': 'User0.id' }
+                }]
             });
         });
     });
@@ -214,13 +135,13 @@ describe('Session', () => {
             session.findOne(User);
             expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
                 'columns': [
-                    'User.id',
-                    'User.firstName',
-                    'User.lastName',
-                    'User.username',
-                    'User.email',
-                    'User.register_date',
-                    'User.role'
+                    ['User.id', 'User_id'],
+                    ['User.firstName', 'User_firstName'],
+                    ['User.lastName', 'User_lastName'],
+                    ['User.username', 'User_username'],
+                    ['User.email', 'User_email'],
+                    ['User.register_date', 'User_register_date'],
+                    ['User.role', 'User_role']
                 ],
                 'from': 'users',
                 'as': 'User',
@@ -234,13 +155,13 @@ describe('Session', () => {
             session.findOnly(User);
             expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
                 'columns': [
-                    'User.id',
-                    'User.firstName',
-                    'User.lastName',
-                    'User.username',
-                    'User.email',
-                    'User.register_date',
-                    'User.role'
+                    ['User.id', 'User_id'],
+                    ['User.firstName', 'User_firstName'],
+                    ['User.lastName', 'User_lastName'],
+                    ['User.username', 'User_username'],
+                    ['User.email', 'User_email'],
+                    ['User.register_date', 'User_register_date'],
+                    ['User.role', 'User_role']
                 ],
                 'from': 'users',
                 'as': 'User',

--- a/test/unit/relationships/OneToOneRelationshipTest.js
+++ b/test/unit/relationships/OneToOneRelationshipTest.js
@@ -1,0 +1,206 @@
+import { expect } from 'chai';
+import { Session, adapterSpy } from '../utils';
+
+const session = new Session();
+
+const User = session.model('User', {
+    'id': {
+        'type': Number,
+        'primary': true
+    }
+}, {
+    'table': 'users'
+});
+
+const Client = session.model('Client', {
+    'name': {
+        'type': String
+    }
+}, {
+    'extends': User,
+    'table': 'clients'
+});
+
+const Representative = session.model('Representative', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'client': {
+        'ref': Client,
+        'relation': 'one-to-one',
+        'column': 'client_id',
+        'eager': true
+    }
+}, {
+    'table': 'reps'
+});
+
+const Post = session.model('Post', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'author': {
+        'ref': User,
+        'relation': 'one-to-one',
+        'column': 'author_id'
+    },
+    'editor': {
+        'ref': User,
+        'relation': 'one-to-one',
+        'column': 'editor_id'
+    }
+}, {
+    'table': 'posts'
+});
+
+const Comment = session.model('Comment', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'author': {
+        'ref': User,
+        'relation': 'one-to-one',
+        'column': 'author_id',
+        'eager': true
+    }
+}, {
+    'table': 'comments'
+});
+
+describe('One-To-One Relationships', () => {
+    beforeEach(() => {
+        session.adapter = adapterSpy();
+    });
+
+    it('Basic join', () => {
+        session.findAll(Comment);
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Comment.id', 'Comment_id'],
+                ['User0.id', 'User0_id']
+            ],
+            'from': 'comments',
+            'as': 'Comment',
+            'join': [
+                {
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': {
+                        'Comment.author_id': 'User0.id'
+                    }
+                }
+            ]
+        });
+    });
+
+    it('Join with multiple refs to same model', () => {
+        session.findAll(Post, null, {
+            'include': ['Post.author', 'Post.editor']
+        });
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Post.id', 'Post_id'],
+                ['User0.id', 'User0_id'],
+                ['User1.id', 'User1_id']
+            ],
+            'from': 'posts',
+            'as': 'Post',
+            'join': [
+                {
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': {
+                        'Post.author_id': 'User0.id'
+                    }
+                }, {
+                    'to': 'users',
+                    'as': 'User1',
+                    'on': {
+                        'Post.editor_id': 'User1.id'
+                    }
+                }
+            ]
+        });
+    });
+
+    it('Will not join lazy-loaded relations', () => {
+        session.findAll(Post);
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Post.id', 'Post_id'],
+                ['Post.author_id', 'Post_author_id'],
+                ['Post.editor_id', 'Post_editor_id']
+            ],
+            'from': 'posts',
+            'as': 'Post'
+        });
+    });
+
+    it('Will join included lazy-load relations', () => {
+        session.findAll(Post, null, {
+            'include': ['Post.author']
+        });
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Post.id', 'Post_id'],
+                ['User0.id', 'User0_id'],
+                ['Post.editor_id', 'Post_editor_id']
+            ],
+            'from': 'posts',
+            'as': 'Post',
+            'join': [
+                {
+                    'to': 'users',
+                    'as': 'User0',
+                    'on': {
+                        'Post.author_id': 'User0.id'
+                    }
+                }
+            ]
+        });
+    });
+
+    it('Will not join excluded eagerly-loaded relations', () => {
+        session.findAll(Comment, null, {
+            'exclude': ['Comment.author']
+        });
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Comment.id', 'Comment_id']
+            ],
+            'from': 'comments',
+            'as': 'Comment'
+        });
+    });
+
+    it('Automatically loads ancestors of relations', () => {
+        session.findAll(Representative);
+        expect(session.adapter.find.getCall(0).args[0]).to.deep.equal({
+            'columns': [
+                ['Representative.id', 'Representative_id'],
+                ['Client0.name', 'Client0_name'],
+                ['User0.id', 'User0_id']
+            ],
+            'from': 'reps',
+            'as': 'Representative',
+            'join': [
+                {
+                    'as': 'Client0',
+                    'on': {
+                        'Representative.client_id': 'Client0.id'
+                    },
+                    'to': 'clients'
+                }, {
+                    'as': 'User0',
+                    'on': {
+                        'Client0.id': 'User0.id'
+                    },
+                    'to': 'users'
+                }
+            ]
+        });
+    });
+});

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,0 +1,13 @@
+import sinon from 'sinon';
+import Session from '../../src/Session';
+
+export const adapterSpy = function () {
+    return {
+        'find': sinon.spy(),
+        'create': sinon.spy(),
+        'update': sinon.spy(),
+        'remove': sinon.spy()
+    };
+};
+
+export { Session };

--- a/test/unit/utils/graph-utils-test.js
+++ b/test/unit/utils/graph-utils-test.js
@@ -1,0 +1,102 @@
+/* eslint no-unused-expressions: "off" */
+
+import { expect } from 'chai';
+import { Session } from '../utils';
+import * as GraphUtils from '../../../src/utils/graph-utils';
+
+const session = new Session();
+
+session.model('User', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'name': {
+        'type': String
+    }
+}, {
+    'table': 'users'
+});
+
+session.model('Post', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'author': {
+        'ref': 'User',
+        'relation': 'one-to-one',
+        'column': 'author_id'
+    },
+    'editor': {
+        'ref': 'User',
+        'relation': 'one-to-one',
+        'column': 'editor_id'
+    }
+}, {
+    'table': 'posts'
+});
+
+session.model('Comment', {
+    'id': {
+        'type': Number,
+        'primary': true
+    },
+    'post': {
+        'ref': 'Post',
+        'relation': 'many-to-one',
+        'column': 'post_id'
+    },
+    'author': {
+        'ref': 'User',
+        'relation': 'one-to-one',
+        'column': 'author_id'
+    }
+}, {
+    'table': 'comments'
+});
+
+describe('Graph Utilities tests', () => {
+    describe('resolveGraph()', () => {
+        it('Resolves single segment graph', () => {
+            const GRAPH = 'Comment';
+            const result = GraphUtils.resolveGraph(GRAPH, session);
+            expect(result).to.deep.equal([
+                { 'key': 'Comment', 'ref': 'Comment' }
+            ]);
+        });
+
+        it('Returns null on invalid single segment graph', () => {
+            const GRAPH = 'NotAnEntity';
+            const result = GraphUtils.resolveGraph(GRAPH, session);
+            expect(result).to.be.null;
+        });
+
+        it('Resolves polysegmented graph', () => {
+            const GRAPH = 'Comment.post.author';
+            const result = GraphUtils.resolveGraph(GRAPH, session);
+            expect(result).to.deep.equal([
+                { 'key': 'Comment', 'ref': 'Comment' },
+                { 'key': 'post', 'ref': 'Post' },
+                { 'key': 'author', 'ref': 'User' }
+            ]);
+        });
+
+        it('Returns null on invalid polysegmented graph', () => {
+            const GRAPH = 'Comment.post.invalid';
+            const result = GraphUtils.resolveGraph(GRAPH, session);
+            expect(result).to.be.null;
+        });
+
+        it('Resolves non-referential terminal field', () => {
+            const GRAPH = 'Comment.post.author.name';
+            const result = GraphUtils.resolveGraph(GRAPH, session);
+            expect(result).to.deep.equal([
+                { 'key': 'Comment', 'ref': 'Comment' },
+                { 'key': 'post', 'ref': 'Post' },
+                { 'key': 'author', 'ref': 'User' },
+                { 'key': 'name', 'type': String }
+            ]);
+        });
+    });
+});

--- a/test/unit/utils/graph-utils-test.js
+++ b/test/unit/utils/graph-utils-test.js
@@ -6,7 +6,7 @@ import * as GraphUtils from '../../../src/utils/graph-utils';
 
 const session = new Session();
 
-session.model('User', {
+const User = session.model('User', {
     'id': {
         'type': Number,
         'primary': true
@@ -18,18 +18,18 @@ session.model('User', {
     'table': 'users'
 });
 
-session.model('Post', {
+const Post = session.model('Post', {
     'id': {
         'type': Number,
         'primary': true
     },
     'author': {
-        'ref': 'User',
+        'ref': User,
         'relation': 'one-to-one',
         'column': 'author_id'
     },
     'editor': {
-        'ref': 'User',
+        'ref': User,
         'relation': 'one-to-one',
         'column': 'editor_id'
     }
@@ -37,18 +37,18 @@ session.model('Post', {
     'table': 'posts'
 });
 
-session.model('Comment', {
+const Comment = session.model('Comment', {
     'id': {
         'type': Number,
         'primary': true
     },
     'post': {
-        'ref': 'Post',
+        'ref': Post,
         'relation': 'many-to-one',
         'column': 'post_id'
     },
     'author': {
-        'ref': 'User',
+        'ref': User,
         'relation': 'one-to-one',
         'column': 'author_id'
     }
@@ -60,41 +60,41 @@ describe('Graph Utilities tests', () => {
     describe('resolveGraph()', () => {
         it('Resolves single segment graph', () => {
             const GRAPH = 'Comment';
-            const result = GraphUtils.resolveGraph(GRAPH, session);
+            const result = GraphUtils.resolveGraph(GRAPH, Comment);
             expect(result).to.deep.equal([
-                { 'key': 'Comment', 'ref': 'Comment' }
+                { 'key': 'Comment', 'ref': Comment }
             ]);
         });
 
         it('Returns null on invalid single segment graph', () => {
             const GRAPH = 'NotAnEntity';
-            const result = GraphUtils.resolveGraph(GRAPH, session);
+            const result = GraphUtils.resolveGraph(GRAPH, Comment);
             expect(result).to.be.null;
         });
 
         it('Resolves polysegmented graph', () => {
             const GRAPH = 'Comment.post.author';
-            const result = GraphUtils.resolveGraph(GRAPH, session);
+            const result = GraphUtils.resolveGraph(GRAPH, Comment);
             expect(result).to.deep.equal([
-                { 'key': 'Comment', 'ref': 'Comment' },
-                { 'key': 'post', 'ref': 'Post' },
-                { 'key': 'author', 'ref': 'User' }
+                { 'key': 'Comment', 'ref': Comment },
+                { 'key': 'post', 'ref': Post },
+                { 'key': 'author', 'ref': User }
             ]);
         });
 
         it('Returns null on invalid polysegmented graph', () => {
             const GRAPH = 'Comment.post.invalid';
-            const result = GraphUtils.resolveGraph(GRAPH, session);
+            const result = GraphUtils.resolveGraph(GRAPH, Comment);
             expect(result).to.be.null;
         });
 
         it('Resolves non-referential terminal field', () => {
             const GRAPH = 'Comment.post.author.name';
-            const result = GraphUtils.resolveGraph(GRAPH, session);
+            const result = GraphUtils.resolveGraph(GRAPH, Comment);
             expect(result).to.deep.equal([
-                { 'key': 'Comment', 'ref': 'Comment' },
-                { 'key': 'post', 'ref': 'Post' },
-                { 'key': 'author', 'ref': 'User' },
+                { 'key': 'Comment', 'ref': Comment },
+                { 'key': 'post', 'ref': Post },
+                { 'key': 'author', 'ref': User },
                 { 'key': 'name', 'type': String }
             ]);
         });

--- a/test/unit/utils/identifier-utils-test.js
+++ b/test/unit/utils/identifier-utils-test.js
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import * as IdentUtils from '../../../src/utils/identifier-utils';
+
+describe('Identifier Utilities tests', () => {
+    describe('prefixAlias()', () => {
+        it('Prepends alias', () => {
+            const result = IdentUtils.prefixAlias('name', 'Client0');
+            expect(result).to.equal('Client0.name');
+        });
+        it('Returns column if no alias given', () => {
+            const result = IdentUtils.prefixAlias('name');
+            expect(result).to.equal('name');
+        });
+    });
+});

--- a/test/unit/utils/model-utils-test.js
+++ b/test/unit/utils/model-utils-test.js
@@ -1,0 +1,165 @@
+/* eslint no-unused-expressions: "off" */
+
+import { expect } from 'chai';
+import { Session } from '../utils';
+import * as ModelUtils from '../../../src/utils/model-utils';
+
+const session = new Session();
+const Vehicle = session.model('Vehicle', {});
+const Car = session.model('Car', {}, {
+    'extends': Vehicle
+});
+const Sedan = session.model('Sedan', {
+    'numDoors': {
+        'type': Number
+    }
+}, {
+    'extends': Car
+});
+
+describe('Model Utilities tests', () => {
+    describe('getModel()', () => {
+        it('Fails when no argument given', () => {
+            const result = ModelUtils.getModel();
+            expect(result).to.be.null;
+        });
+        it('Fails when given non-model', () => {
+            const result = ModelUtils.getModel({});
+            expect(result).to.be.null;
+        });
+        it('Returns model class given', () => {
+            const result = ModelUtils.getModel(Car);
+            expect(result).to.equal(Car);
+        });
+        it('Returns model class for instance', () => {
+            const car = new Car();
+            const result = ModelUtils.getModel(car);
+            expect(result).to.not.equal(car);
+            expect(result).to.equal(Car);
+        });
+    });
+
+    describe('getName()', () => {
+        it('Returns name for model class', () => {
+            const result = ModelUtils.getName(Car);
+            expect(result).to.equal('Car');
+        });
+        it('Returns name for model instance', () => {
+            const result = ModelUtils.getName(new Car());
+            expect(result).to.equal('Car');
+        });
+    });
+
+    describe('getParent()', () => {
+        it('Returns parent for model class', () => {
+            const result = ModelUtils.getParent(Sedan);
+            expect(result).to.equal(Car);
+        });
+        it('Returns parent for model instance', () => {
+            const result = ModelUtils.getParent(new Sedan());
+            expect(result).to.equal(Car);
+        });
+        it('Returns null if given model is root', () => {
+            const result = ModelUtils.getParent(Vehicle);
+            expect(result).to.be.null;
+        });
+        it('Returns null if argument missing', () => {
+            const result = ModelUtils.getParent();
+            expect(result).to.be.null;
+        });
+    });
+
+    describe('getAncestors()', () => {
+        it('Returns ancestors for model class', () => {
+            const result = ModelUtils.getAncestors(Sedan, session);
+            expect(result).to.deep.equal([Car, Vehicle]);
+        });
+        it('Returns ancestors for model instance', () => {
+            const result = ModelUtils.getAncestors(new Sedan(), session);
+            expect(result).to.deep.equal([Car, Vehicle]);
+        });
+    });
+
+    describe('getField()', () => {
+        it('Returns field for model class', () => {
+            const result = ModelUtils.getField(Sedan, 'numDoors');
+            expect(result).to.deep.equal({
+                'column': 'numDoors',
+                'name': 'numDoors',
+                'type': Number,
+                'owningModel': 'Sedan'
+            });
+        });
+        it('Returns field for model instance', () => {
+            const result = ModelUtils.getField(new Sedan(), 'numDoors');
+            expect(result).to.deep.equal({
+                'column': 'numDoors',
+                'name': 'numDoors',
+                'type': Number,
+                'owningModel': 'Sedan'
+            });
+        });
+    });
+
+    describe('getFields()', () => {
+        it('Returns fields for model class', () => {
+            const result = ModelUtils.getFields(Sedan);
+            expect(result).to.deep.equal({
+                'numDoors': {
+                    'column': 'numDoors',
+                    'name': 'numDoors',
+                    'owningModel': 'Sedan',
+                    'type': Number
+                }
+            });
+        });
+        it('Returns fields for model instance', () => {
+            const result = ModelUtils.getFields(new Sedan());
+            expect(result).to.deep.equal({
+                'numDoors': {
+                    'column': 'numDoors',
+                    'name': 'numDoors',
+                    'owningModel': 'Sedan',
+                    'type': Number
+                }
+            });
+        });
+    });
+
+    describe('getAllFields()', () => {
+        it('Returns fields for model class', () => {
+            const result = ModelUtils.getAllFields(Sedan, session);
+            expect(result).to.deep.equal({
+                'numDoors': {
+                    'column': 'numDoors',
+                    'name': 'numDoors',
+                    'owningModel': 'Sedan',
+                    'type': Number
+                }
+            });
+        });
+        it('Returns fields for model instance', () => {
+            const result = ModelUtils.getAllFields(new Sedan(), session);
+            expect(result).to.deep.equal({
+                'numDoors': {
+                    'column': 'numDoors',
+                    'name': 'numDoors',
+                    'owningModel': 'Sedan',
+                    'type': Number
+                }
+            });
+        });
+    });
+
+    describe('getChangedFields', () => {
+        it('Returns array of field names for model instance', () => {
+            const sedan = new Sedan({
+                'numDoors': 4,
+                'numWheels': 4,
+                'numWindows': 6
+            });
+            const result = ModelUtils.getChangedFields(sedan, session);
+            expect(result).to.deep.equal(['numDoors']);
+        });
+    });
+});


### PR DESCRIPTION
* Query building is now the providence of the QueryBuilder implementations, no longer of the session. The session should be primarily for communicating with the dialects and underlying datastores.
* Zero query building operations require an actual session. This is primarily because we want to support multiple sessions in the same environment, so that we can chat with multiple datastores at once. This means that we explicitly pass around model definitions a lot. This has the added advantage that the session does _not_ get passed around. Seems a bit cleaner that way. The session should know about the domain, but not the other way around.
* The basics for one-to-one relationships are now roughly in. Relationships can be eagerly loaded, but the default is lazy.